### PR TITLE
Update lecture6.tex

### DIFF
--- a/Course/Sections/lecture6.tex
+++ b/Course/Sections/lecture6.tex
@@ -85,7 +85,7 @@ using Feynman parameters. The general formula
       \Gamma(\alpha_n)}\, \int_0^1 dx_1\, x_1^{\alpha_1 -1} \ldots
       \int_0^1 dx_n\, x_n^{\alpha_n -1} \nonumber \\
     & \quad \times \delta\left(1-x_1-\ldots -x_n\right)\,
-      \frac{1}{\left(\alpha_1 A_1 + \ldots + \alpha_n
+      \frac{1}{\left(x_1 A_1 + \ldots + x_n
       A_n\right)^{\alpha_1 + \ldots + \alpha_n}}\, , 
 \end{align}
 can be applied to the integrand above, yielding


### PR DESCRIPTION
Changed alpha's to x's in the denominator of the expression for the Feynman parameterization, to match the expressions in problem sheet 7 and the one found in “An Introduction to Quantum Field Theory” by Peskin and Schroeder. https://en.wikipedia.org/wiki/Feynman_parametrization